### PR TITLE
Fix for Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # Copyright 2020, Trevor Sundberg. See LICENSE.md
-FROM ubuntu:20.10
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
20.10 had an issue (well, because it was deprecated)
And needed to add the non-interactive flag because it was stuck in the TimeZone selection menu

Besides that, some samples work, but the ones with a cmake list dont build