### PR TITLE
fix: lock rustc to support wasm32-wasi target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.13.4)
 project(WASM2BRS VERSION 1.0.0)
 
+# Require C++11 standard for the project
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_subdirectory(third_party/wabt)
 add_subdirectory(third_party/binaryen)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ git submodule update --init --recursive
 
 To run `make` without the Docker image (not recommended) be sure to install the same dependencies as listed in the `Dockerfile`.
 
+## Build Requirements
+- C++11 compatible compiler
+- CMake 3.13.4 or higher
+- If building manually, set the C++11 standard explicitly:
+  ```bash
+  mkdir -p build/wasm2brs
+  cd build/wasm2brs
+  cmake ../.. -DCMAKE_CXX_FLAGS="-std=c++11"
+  make -j
+  ```
+
 # Running the samples
 ```bash
 ./run.sh make doom

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,10 +28,10 @@ ENV WASMER_DIR="/home/user/.wasmer"
 ENV WASMER_CACHE_DIR="/home/user/.wasmer/cache"
 ENV PATH="/home/user/.wasmer/bin:/home/user/.wasienv/bin/:${PATH}:/home/user/.wasmer/globals/wapm_packages/.bin"
 
-RUN curl -sSf https://sh.rustup.rs | bash -s -- -y
+RUN curl -sSf https://sh.rustup.rs | bash -s -- -y --default-toolchain=1.81.0
 ENV PATH="/home/user/.cargo/bin:${PATH}"
 RUN rustup target add wasm32-wasi
-RUN cargo install cargo-wasi
+RUN cargo install --locked cargo-wasi
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD echo "No command specified"

--- a/src/wasm2brs.cc
+++ b/src/wasm2brs.cc
@@ -124,7 +124,7 @@ int ProgramMain(int argc, char** argv) {
       result = ParseWatModule(lexer.get(), &module, &errors, &options);
     } else {
       location_type = Location::Type::Binary;
-      module = std::make_unique<wabt::Module>();
+    module = MakeUnique<wabt::Module>();
       const bool kStopOnFirstError = true;
       const bool kFailOnCustomSectionError = true;
       ReadBinaryOptions options(s_features, s_log_stream.get(),


### PR DESCRIPTION
support #10. I have tried to validate this but an M1 MBP fails due to:

CMakeOutput.log
```
The target system is: Generic - 1 - x86
The host system is: Linux - 6.10.14-linuxkit - aarch64
```

and GitHub Codespaces crashes due to limited resource. Will try an x86 machine if I can find one